### PR TITLE
Simpler and faster jsonKeys implementation

### DIFF
--- a/console.go
+++ b/console.go
@@ -345,40 +345,15 @@ func (w *ConsoleWriter) writet(out io.Writer, p []byte) (n int, err error) {
 }
 
 func jsonKeys(data []byte) (keys []string) {
-	var depth, count int
-
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	for {
-		token, err := decoder.Token()
-		if err != nil {
-			break
-		}
-		// fmt.Printf("==== %d %d <%T> %v\n", depth, count, token, token)
-		switch token.(type) {
-		case json.Delim:
-			switch token.(json.Delim) {
-			case '{', '[':
-				depth++
-			case '}', ']':
-				depth--
-				if depth == 1 {
-					count++
-				}
-			}
-		case string:
-			if depth == 1 {
-				if count%2 == 0 {
-					keys = append(keys, token.(string))
-				}
-				count++
-			}
-		default:
-			if depth == 1 {
-				count++
-			}
-		}
+	tmp := make(map[string]interface{})
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return
 	}
-
+	keys = make([]string, 0, len(tmp))
+	for k := range tmp {
+		keys = append(keys, k)
+	}
 	return
 }
 


### PR DESCRIPTION
It turns out the simpler way that just use `json.Unmarshal` is faster than calling `Decode` to parse it manually.

```
name               old time/op    new time/op    delta
JSONKeys/short-12    2.54µs ± 1%    1.60µs ± 2%   ~     (p=0.100 n=3+3)
JSONKeys/long-12     5.61µs ± 0%    3.61µs ± 0%   ~     (p=0.100 n=3+3)

name               old alloc/op   new alloc/op   delta
JSONKeys/short-12    1.64kB ± 0%    1.06kB ± 0%   ~     (p=0.100 n=3+3)
JSONKeys/long-12     2.74kB ± 0%    1.30kB ± 0%   ~     (p=0.100 n=3+3)

name               old allocs/op  new allocs/op  delta
JSONKeys/short-12      45.0 ± 0%      20.0 ± 0%   ~     (p=0.100 n=3+3)
JSONKeys/long-12       89.0 ± 0%      37.0 ± 0%   ~     (p=0.100 n=3+3)
```