### PR TITLE
A new MultiWriters design that doesn't require parsing levels

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -43,7 +43,7 @@ type Logger struct {
 	// Writer specifies the writer of output. It uses os.Stderr in if empty.
 	Writer io.Writer
 
-	Writers *MultiWriter
+	MultiWriters *MultiWriter
 }
 
 const (
@@ -285,8 +285,8 @@ func (l *Logger) header(level Level) *Event {
 		e.exit = false
 		e.panic = true
 	}
-	if l.Writers != nil {
-		e.w = l.Writers.CombineWriters(level)
+	if l.MultiWriters != nil {
+		e.w = l.MultiWriters.CombineWriters(level)
 	} else if l.Writer != nil {
 		e.w = l.Writer
 	} else {

--- a/logger.go
+++ b/logger.go
@@ -286,7 +286,7 @@ func (l *Logger) header(level Level) *Event {
 		e.panic = true
 	}
 	if l.MultiWriters != nil {
-		e.w = l.MultiWriters.CombineWriters(level)
+		e.w = l.MultiWriters.GetWriterByLevel(level)
 	} else if l.Writer != nil {
 		e.w = l.Writer
 	} else {

--- a/logger.go
+++ b/logger.go
@@ -42,6 +42,8 @@ type Logger struct {
 
 	// Writer specifies the writer of output. It uses os.Stderr in if empty.
 	Writer io.Writer
+
+	Writers *MultiWriter
 }
 
 const (
@@ -283,7 +285,9 @@ func (l *Logger) header(level Level) *Event {
 		e.exit = false
 		e.panic = true
 	}
-	if l.Writer != nil {
+	if l.Writers != nil {
+		e.w = l.Writers.CombineWriters(level)
+	} else if l.Writer != nil {
 		e.w = l.Writer
 	} else {
 		e.w = os.Stderr

--- a/logger.go
+++ b/logger.go
@@ -43,7 +43,9 @@ type Logger struct {
 	// Writer specifies the writer of output. It uses os.Stderr in if empty.
 	Writer io.Writer
 
-	leveledWriterRouter LeveledWriterRouter
+	// LeveledWriter decides which writers to write for each level.
+	// When this field is set, the Writer field is ignored.
+	LeveledWriter LeveledWriter
 }
 
 const (
@@ -285,8 +287,8 @@ func (l *Logger) header(level Level) *Event {
 		e.exit = false
 		e.panic = true
 	}
-	if l.leveledWriterRouter != nil {
-		e.w = l.leveledWriterRouter.GetWriterByLevel(level)
+	if l.LeveledWriter != nil {
+		e.w = wrapLeveledWriter{Level: level, LeveledWriter: l.LeveledWriter}
 	} else if l.Writer != nil {
 		e.w = l.Writer
 	} else {

--- a/logger.go
+++ b/logger.go
@@ -43,7 +43,7 @@ type Logger struct {
 	// Writer specifies the writer of output. It uses os.Stderr in if empty.
 	Writer io.Writer
 
-	MultiWriters *MultiWriter
+	leveledWriterRouter LeveledWriterRouter
 }
 
 const (
@@ -285,8 +285,8 @@ func (l *Logger) header(level Level) *Event {
 		e.exit = false
 		e.panic = true
 	}
-	if l.MultiWriters != nil {
-		e.w = l.MultiWriters.GetWriterByLevel(level)
+	if l.leveledWriterRouter != nil {
+		e.w = l.leveledWriterRouter.GetWriterByLevel(level)
 	} else if l.Writer != nil {
 		e.w = l.Writer
 	} else {

--- a/multi.go
+++ b/multi.go
@@ -63,13 +63,13 @@ func (w *MultiWriter) GetWriterByLevel(level Level) io.Writer {
 	if len(w.levelWriters) == 0 {
 		w.levelWriters = make([]io.Writer, 8)
 		if w.InfoWriter != nil {
-			w.levelWriters[int(InfoLevel)] = w.InfoWriter
+			w.levelWriters[int(TraceLevel)+1] = w.InfoWriter
 		}
 		if w.WarnWriter != nil {
-			w.levelWriters[int(WarnLevel)] = w.WarnWriter
+			w.levelWriters[int(WarnLevel)+1] = w.WarnWriter
 		}
 		if w.ErrorWriter != nil {
-			w.levelWriters[int(ErrorLevel)] = w.ErrorWriter
+			w.levelWriters[int(ErrorLevel)+1] = w.ErrorWriter
 		}
 		if w.StderrWriter != nil {
 			lvl := int(w.StderrLevel)
@@ -83,7 +83,7 @@ func (w *MultiWriter) GetWriterByLevel(level Level) io.Writer {
 	if level < InfoLevel {
 		level = InfoLevel
 	}
-	return CombinedWriter(w.levelWriters[:int(level)+1])
+	return CombinedWriter(w.levelWriters[:int(level)+2])
 }
 
 // Close implements io.Closer, and closes the underlying leveledWriterRouter.

--- a/multi.go
+++ b/multi.go
@@ -5,6 +5,10 @@ import (
 	"io"
 )
 
+type LeveledWriterRouter interface {
+	GetWriterByLevel(level Level) io.Writer
+}
+
 type CombinedWriter []io.Writer
 
 func (cw CombinedWriter) Write(p []byte) (n int, firstErr error) {
@@ -82,7 +86,7 @@ func (w *MultiWriter) GetWriterByLevel(level Level) io.Writer {
 	return CombinedWriter(w.levelWriters[:int(level)+1])
 }
 
-// Close implements io.Closer, and closes the underlying MultiWriters.
+// Close implements io.Closer, and closes the underlying leveledWriterRouter.
 func (w *MultiWriter) Close() (err error) {
 	for _, writer := range []io.Writer{
 		w.InfoWriter,

--- a/multi.go
+++ b/multi.go
@@ -52,7 +52,6 @@ type MultiWriter struct {
 
 	// One writer slot for each of the 8 levels
 	levelWriters []io.Writer
-	levels       []Level
 }
 
 func (w *MultiWriter) GetWriterByLevel(level Level) io.Writer {
@@ -77,7 +76,10 @@ func (w *MultiWriter) GetWriterByLevel(level Level) io.Writer {
 			}
 		}
 	}
-	return CombinedWriter(w.levelWriters[:int(level)])
+	if level < InfoLevel {
+		level = InfoLevel
+	}
+	return CombinedWriter(w.levelWriters[:int(level)+1])
 }
 
 // Close implements io.Closer, and closes the underlying MultiWriters.

--- a/multi.go
+++ b/multi.go
@@ -52,9 +52,10 @@ type MultiWriter struct {
 
 	// One writer slot for each of the 8 levels
 	levelWriters []io.Writer
+	levels       []Level
 }
 
-func (w *MultiWriter) CombineWriters(level Level) CombinedWriter {
+func (w *MultiWriter) GetWriterByLevel(level Level) io.Writer {
 	// TODO: Make sure the writers can not be updated directly
 	if len(w.levelWriters) == 0 {
 		w.levelWriters = make([]io.Writer, 8)

--- a/multi_test.go
+++ b/multi_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestNewMultiWriters(t *testing.T) {
+func TestLoggerWithLeveledWriters(t *testing.T) {
 	// TODO: Use mock writers to validate that the logs are routed correctly
 	w := &MultiWriter{
 		InfoWriter: &FileWriter{
@@ -24,9 +24,9 @@ func TestNewMultiWriters(t *testing.T) {
 		},
 	}
 	logger := Logger{
-		Level:               InfoLevel,
-		Caller:              1,
-		leveledWriterRouter: w,
+		Level:         InfoLevel,
+		Caller:        1,
+		LeveledWriter: w,
 	}
 	assertNLogs := func(want int) {
 		matches, _ := filepath.Glob("file-*.*.log")
@@ -229,9 +229,9 @@ func BenchmarkNewMultiWriter(b *testing.B) {
 		},
 	}
 	logger := Logger{
-		Level:               InfoLevel,
-		Caller:              1,
-		leveledWriterRouter: w,
+		Level:         InfoLevel,
+		Caller:        1,
+		LeveledWriter: w,
 	}
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/multi_test.go
+++ b/multi_test.go
@@ -24,9 +24,9 @@ func TestNewMultiWriters(t *testing.T) {
 		},
 	}
 	logger := Logger{
-		Level:        InfoLevel,
-		Caller:       1,
-		MultiWriters: w,
+		Level:               InfoLevel,
+		Caller:              1,
+		leveledWriterRouter: w,
 	}
 	assertNLogs := func(want int) {
 		matches, _ := filepath.Glob("file-*.*.log")
@@ -229,9 +229,9 @@ func BenchmarkNewMultiWriter(b *testing.B) {
 		},
 	}
 	logger := Logger{
-		Level:        InfoLevel,
-		Caller:       1,
-		MultiWriters: w,
+		Level:               InfoLevel,
+		Caller:              1,
+		leveledWriterRouter: w,
 	}
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/multi_test.go
+++ b/multi_test.go
@@ -10,6 +10,49 @@ import (
 	"testing"
 )
 
+func TestNewMultiWriters(t *testing.T) {
+	// TODO: Use mock writers to validate that the logs are routed correctly
+	w := &MultiWriter{
+		InfoWriter: &FileWriter{
+			Filename: "file-info.log",
+		},
+		WarnWriter: &FileWriter{
+			Filename: "file-warn.log",
+		},
+		ErrorWriter: &FileWriter{
+			Filename: "file-error.log",
+		},
+	}
+	logger := Logger{
+		Level:  InfoLevel,
+		Caller: 1,
+		Writers: w,
+	}
+	assertNLogs := func (want int) {
+		matches, _ := filepath.Glob("file-*.*.log")
+		if len(matches) != want {
+			t.Fatalf("filepath glob return %+v number mismatch, got %+v want %+v", matches, len(matches), want)
+		}
+	}
+
+	logger.Info().Int("id", 42).Msg("I'm loving it.")
+	assertNLogs(1)
+
+	logger.Warn().Int("id", 43).Msg("I double dare you.")
+	assertNLogs(2)
+
+	logger.Error().Str("action", "cleanup").Msg("World")
+	assertNLogs(3)
+
+	matches, _ := filepath.Glob("file-*.log")
+	for i := range matches {
+		err := os.Remove(matches[i])
+		if err != nil {
+			t.Fatalf("os remove %s error: %+v", matches[i], err)
+		}
+	}
+}
+
 func TestMultiWriter(t *testing.T) {
 	w := &MultiWriter{
 		InfoWriter: &FileWriter{


### PR DESCRIPTION
In the current implementation, `MultiWriter` is used as `Logger.Writer`. Each time a message is written, we need to first parse the level from the input.

I can't help wondering if this can be avoided. In this pull request (still WIP), I want to propose a new design to avoid the level parsing step.

Instead of making `MultiWriter` an `io.Writer`, we just make it an optional field for `Logger`. If it's set, we use it instead of `Writer`.
When creating an `Event`, we use the level to decide what writers to use by calling `MultiWriter.CombineWriters`, which collects the matched writers into one `io.Writer` implementation called `CombinedWriter`:

```go
type CombineWriter []io.Writer

func (cw CombineWriter) Write(p []byte) (n int, firstErr error) {
	for _, w := range cw {
		var err error
		n, err = w.Write(p)
		if err != nil && firstErr == nil {
			firstErr = err
		}
	}
	return n, firstErr
}

var _ io.Writer = CombineWriter{}
```

Please let me know what you think about this design. Thanks.

