### PR TITLE
Fix missing err entry in logger.Err

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -241,7 +241,13 @@ func (l *Logger) Err(err error) (e *Entry) {
 		return nil
 	}
 	e = l.header(level)
-	if e != nil && l.Caller > 0 {
+	if e == nil {
+		return nil
+	}
+	if level == ErrorLevel {
+		e = e.Err(err)
+	}
+	if l.Caller > 0 {
 		_, file, line, _ := runtime.Caller(l.Caller)
 		e.caller(file, line, DefaultLogger.FullpathCaller)
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -497,6 +498,20 @@ func TestLoggerErrorStack(t *testing.T) {
 	logger.Info().Err(errno(1)).Msg("log errno(1) here")
 	logger.Info().Err(errno(2)).Msg("log errno(2) here")
 	logger.Info().Err(errno(3)).Msg("log errno(3) here")
+}
+
+func TestFixMissingErrEntry(t *testing.T) {
+	var b bytes.Buffer
+	logger := Logger{Level: TraceLevel, Writer: &IOWriter{Writer: &b}}
+	logger.Err(errors.New("test error")).Msg("log error here")
+	if !strings.Contains(b.String(), `"error":"test error"`) {
+		t.Fatal("logger.Err need an error entry if err != nil")
+	}
+	b.Reset()
+	logger.Err(nil).Msg("log info here")
+	if !strings.Contains(b.String(), `"level":"info"`) {
+		t.Fatal("logger.Err need info level if err == nil")
+	}
 }
 
 func BenchmarkLogger(b *testing.B) {


### PR DESCRIPTION
As doc showed, `logger.Err(err)` need an `error` entry when `err != nil`. 