### PR TITLE
make entry nil safe

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2034,6 +2034,9 @@ func NewContext(dst []byte) (e *Entry) {
 
 // Value builds the contextual fields.
 func (e *Entry) Value() Context {
+	if e == nil {
+		return nil
+	}
 	return e.buf
 }
 


### PR DESCRIPTION
`*entry.Value()` panics if entry is nil.

```go
log.DefaultLogger.Trace().Value() // panics, ideally shouldn't
```