### PR TITLE
feat: add BoolRaw for tsv format

### DIFF
--- a/tsv.go
+++ b/tsv.go
@@ -147,6 +147,18 @@ func (e *TSVEntry) Bool(b bool) *TSVEntry {
 	return e
 }
 
+// BoolRaw append the b as a bool to the entry.
+func (e *TSVEntry) BoolRaw(b bool) *TSVEntry {
+	if b {
+		e.buf = append(e.buf, "true"...)
+		e.buf = append(e.buf, e.sep)
+	} else {
+		e.buf = append(e.buf, "false"...)
+		e.buf = append(e.buf, e.sep)
+	}
+	return e
+}
+
 // Byte append the b as a byte to the entry.
 func (e *TSVEntry) Byte(b byte) *TSVEntry {
 	e.buf = append(e.buf, b, e.sep)

--- a/tsv.go
+++ b/tsv.go
@@ -137,7 +137,7 @@ func (e *TSVEntry) Caller(depth int) *TSVEntry {
 	return e
 }
 
-// Bool append the b as a bool to the entry.
+// Bool append the b as a bool to the entry, the value of output bool is 0 or 1.
 func (e *TSVEntry) Bool(b bool) *TSVEntry {
 	if b {
 		e.buf = append(e.buf, '1', e.sep)
@@ -147,14 +147,12 @@ func (e *TSVEntry) Bool(b bool) *TSVEntry {
 	return e
 }
 
-// BoolRaw append the b as a bool to the entry.
-func (e *TSVEntry) BoolRaw(b bool) *TSVEntry {
+// BoolString append the b as a bool to the entry, the value of output bool is false or true.
+func (e *TSVEntry) BoolString(b bool) *TSVEntry {
 	if b {
-		e.buf = append(e.buf, "true"...)
-		e.buf = append(e.buf, e.sep)
+		e.buf = append(e.buf, 't', 'r', 'u', 'e', e.sep)
 	} else {
-		e.buf = append(e.buf, "false"...)
-		e.buf = append(e.buf, e.sep)
+		e.buf = append(e.buf, 'f', 'a', 'l', 's', 'e', e.sep)
 	}
 	return e
 }

--- a/tsv_test.go
+++ b/tsv_test.go
@@ -15,6 +15,8 @@ func TestTSVLogger(t *testing.T) {
 		Caller(1).
 		Bool(true).
 		Bool(false).
+		BoolRaw(true).
+		BoolRaw(false).
 		Byte('m').
 		Float64(0.618).
 		Int64(123).
@@ -46,6 +48,8 @@ func TestTSVSeparator(t *testing.T) {
 		TimestampMS().
 		Bool(true).
 		Bool(false).
+		BoolRaw(true).
+		BoolRaw(false).
 		Byte('m').
 		Float64(0.618).
 		Int64(123).
@@ -72,6 +76,8 @@ func TestTSVDiscard(t *testing.T) {
 		TimestampMS().
 		Bool(true).
 		Bool(false).
+		BoolRaw(true).
+		BoolRaw(false).
 		Float64(0.618).
 		Int64(123).
 		Uint64(456).

--- a/tsv_test.go
+++ b/tsv_test.go
@@ -15,8 +15,8 @@ func TestTSVLogger(t *testing.T) {
 		Caller(1).
 		Bool(true).
 		Bool(false).
-		BoolRaw(true).
-		BoolRaw(false).
+		BoolString(true).
+		BoolString(false).
 		Byte('m').
 		Float64(0.618).
 		Int64(123).
@@ -48,8 +48,8 @@ func TestTSVSeparator(t *testing.T) {
 		TimestampMS().
 		Bool(true).
 		Bool(false).
-		BoolRaw(true).
-		BoolRaw(false).
+		BoolString(true).
+		BoolString(false).
 		Byte('m').
 		Float64(0.618).
 		Int64(123).
@@ -76,8 +76,8 @@ func TestTSVDiscard(t *testing.T) {
 		TimestampMS().
 		Bool(true).
 		Bool(false).
-		BoolRaw(true).
-		BoolRaw(false).
+		BoolString(true).
+		BoolString(false).
 		Float64(0.618).
 		Int64(123).
 		Uint64(456).


### PR DESCRIPTION
### why

Add `BoolRaw()` method in tsv.go. Use the `BoolRaw` method to output a true or false string. Or I directly changed the `Bool()` method,  output bool's string, such as true, false ???

```go
// Bool append the b as a bool to the entry.
func (e *TSVEntry) Bool(b bool) *TSVEntry {
	if b {
		e.buf = append(e.buf, "true"...)
		e.buf = append(e.buf, e.sep)
		// e.buf = append(e.buf, '1', e.sep) 
	} else {
		// e.buf = append(e.buf, '0', e.sep)
		e.buf = append(e.buf, "false")
		e.buf = append(e.buf, e.sep)
	}
	return e
}
```

### test result

test code 

```go
func TestTSVLogger(t *testing.T) {
	logger := TSVLogger{}

	logger.New().
		Timestamp().
		TimestampMS().
		Caller(1).
		Bool(true).
		Bool(false).
		BoolRaw(true).
		BoolRaw(false).Msg()
}
```

output:

```c
1683102054	1683102054878	tsv_test.go:15	1	0	true	false
```