### PR TITLE
Switch to allow header timestamps to be UTC

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -441,6 +441,9 @@ const smallsString = "00010203040506070809" +
 	"90919293949596979899"
 
 var timeNow = time.Now
+var timeUtcNow = func() time.Time {
+	return time.Now().UTC()
+}
 var timeOffset, timeZone = func() (int64, string) {
 	now := timeNow()
 	_, n := now.Zone()
@@ -458,10 +461,7 @@ func (l *Logger) header(level Level) *Entry {
 	headerTimeZone := timeZone
 
 	if l.TimeUTC {
-		headerTimeFunc = func () time.Time {
-			return time.Now().UTC()
-		}
-
+		headerTimeFunc = timeUtcNow
 		headerTimeOffset = 0
 		headerTimeZone = "Z"
 	}

--- a/logger.go
+++ b/logger.go
@@ -458,12 +458,10 @@ func (l *Logger) silent(level Level) bool {
 func (l *Logger) header(level Level) *Entry {
 	headerTimeFunc := timeNow
 	headerTimeOffset := timeOffset
-	headerTimeZone := timeZone
 
 	if l.TimeUTC {
 		headerTimeFunc = timeUtcNow
 		headerTimeOffset = 0
-		headerTimeZone = "Z"
 	}
 
 	e := epool.Get().(*Entry)
@@ -495,12 +493,12 @@ func (l *Logger) header(level Level) *Entry {
 		} else {
 			// "2006-01-02T15:04:05.999Z07:00"
 			tmp[30] = '"'
-			tmp[29] = headerTimeZone[5]
-			tmp[28] = headerTimeZone[4]
-			tmp[27] = headerTimeZone[3]
-			tmp[26] = headerTimeZone[2]
-			tmp[25] = headerTimeZone[1]
-			tmp[24] = headerTimeZone[0]
+			tmp[29] = timeZone[5]
+			tmp[28] = timeZone[4]
+			tmp[27] = timeZone[3]
+			tmp[26] = timeZone[2]
+			tmp[25] = timeZone[1]
+			tmp[24] = timeZone[0]
 			buf = tmp[:31]
 		}
 		// date time

--- a/syslog_test.go
+++ b/syslog_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package log
 
 import (


### PR DESCRIPTION
Perhaps I'm missing something, but I could not see how to get the header timestamp to be always UTC instead of system local time.

This PR adds a boolean field to `Logger` so that UTC may be enabled, and the logic for this in `header()`

Additionally fix a typo in `Logger` comments and disable running of syslog tests on Windows.