### PR TITLE
Add TestMain function

### DIFF
--- a/go_slog/verify/verify_test.go
+++ b/go_slog/verify/verify_test.go
@@ -22,3 +22,7 @@ func TestVerifyPhusluSlog(t *testing.T) {
 	slogSuite.WarnOnly(warning.ZeroPC)
 	suite.Run(t, slogSuite)
 }
+
+func TestMain(m *testing.M) {
+	warning.WithWarnings(m)
+}

--- a/go_slog/verify/verify_test.go
+++ b/go_slog/verify/verify_test.go
@@ -17,7 +17,6 @@ func TestVerifyPhusluSlog(t *testing.T) {
 	slogSuite.WarnOnly(warning.Duplicates)
 	slogSuite.WarnOnly(warning.DurationMillis)
 	slogSuite.WarnOnly(warning.GroupAttrMsgTop)
-	slogSuite.WarnOnly(warning.LevelVar)
 	slogSuite.WarnOnly(warning.TimeMillis)
 	slogSuite.WarnOnly(warning.ZeroPC)
 	suite.Run(t, slogSuite)


### PR DESCRIPTION
This will generate the warnings block at the end of a verification test. For example:
```
  Required
     1 [Mismatch] Logged record does not match expected
         TestComplexCases: G1+A           M+B | G1+C           M+B | G1   G2+B      M+C | G1+A G2+B      M+C | G1   G2   G3+C M+B | G1+A G2   G3+C M+B | G1   G2+B G3+C M+A | G1+A G2+B G3+C M+D
           {"time":"2024-05-02T12:00:31.995426592-07:00","level":"INFO","msg":"This is a message","group1":{"string":"value","int":-13,"uint":23,"group2":{"aTime":"2024-05-02T12:00:31-07:00","bool":true,"duration":3802000,"group3":{"groupC":{"name":"Goober Snoofus","skidoo":23,"pi":3.141592653589793},"bool":false,"valuer":"Big Tree","duration":1429000,"E":2.718281828459045,"uint64":79}}}}
     1 [ZeroPC] SourceKey logged for zero PC
         TestZeroPC
           {"time":"2024-05-02T12:00:31.997775298-07:00","level":"INFO","source":{"function":"","file":"","line":0},"msg":"This is a message"}
  Suggested
     2 [Duplicates] Duplicate field(s) found
         TestAttributeDuplicate: map[alpha:2 charlie:3]
         TestAttributeWithDuplicate: map[alpha:2 charlie:3]
     1 [DurationMillis] slog.Duration() logs milliseconds instead of nanoseconds
         TestLogAttributes
     1 [TimeMillis] slog.Time() logs milliseconds instead of nanoseconds
         TestLogAttributes: 2024-05-02T12:00:31.996-07:00
  Administrative
     1 [Unused] Unused Warnings(s)
         TestLevelVar: LevelVar

 Handlers by warning:
  Required
    [Mismatch] Logged record does not match expected
      phuslu/slog
    [ZeroPC] SourceKey logged for zero PC
      phuslu/slog
  Suggested
    [Duplicates] Duplicate field(s) found
      phuslu/slog
    [DurationMillis] slog.Duration() logs milliseconds instead of nanoseconds
      phuslu/slog
    [TimeMillis] slog.Time() logs milliseconds instead of nanoseconds
      phuslu/slog
  Administrative
    [Unused] Unused Warnings(s)
      phuslu/slog
```

Any anomalous situation that the verification suite knows about is converted to a warning (by the `-useWarnings` flag). The warnings configured for the `phuslu/slog` handler are listed in `go_slog/verify/verify_test`:
```
	slogSuite.WarnOnly(warning.Duplicates)
	slogSuite.WarnOnly(warning.DurationMillis)
	slogSuite.WarnOnly(warning.GroupAttrMsgTop)
	slogSuite.WarnOnly(warning.LevelVar)
	slogSuite.WarnOnly(warning.TimeMillis)
	slogSuite.WarnOnly(warning.ZeroPC)
```
If you decide to fix these issues the warnings can be removed. For example . You don't have to fix them if you don't want to. The verification suite is not authoritative. Warning definitions:  https://madkins23.github.io/go-slog/warnings.html.