### PR TITLE
Add -args -useWarnings to go test -bench=. sample command line

### DIFF
--- a/go-slog/README.md
+++ b/go-slog/README.md
@@ -11,5 +11,5 @@ go test -v -args -useWarnings
 
 Benchmark
 ```
-go test -v -run=none -bench=.
+go test -v -run=none -bench=. -args -useWarnings
 ```


### PR DESCRIPTION
You'll need this minor change for any version of `go-slog` after `v0.9.10-beta-10`.

I like the way you consolidated the `go-slog` test code. I'm going to steal that for a template if you don't mind.  ;-)
