### PR TITLE
Update `actions/setup-go` and setup Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,11 +11,12 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
           check-latest: true
-      - uses: actions/checkout@v4
+          cache-dependency-path: go.mod
       - name: go mod tidy
         run: |
           mkdir bench
@@ -31,11 +32,12 @@ jobs:
   sloghanders:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
           check-latest: true
-      - uses: actions/checkout@v4
+          cache-dependency-path: go.mod
       - name: go mod tidy
         run: |
           mkdir bench

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         go-version: ['tip', '1.22', '1.21', '1.20', '1.19', '1.18']
     steps:
+      - uses: actions/checkout@v4
       - name: Setup Go
         if: matrix.go-version != 'tip'
         uses: actions/setup-go@master
@@ -28,7 +29,6 @@ jobs:
           sudo tar xJf gotip.linux-amd64.tar.xz -C /usr/local
           sudo ln -sf /usr/local/go/bin/go /usr/bin/go
           go version
-      - uses: actions/checkout@v4
       - name: Build
         run: go build -v -race
       - name: Test
@@ -38,12 +38,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
           check-latest: true
-      - uses: actions/checkout@v4
+          cache-dependency-path: go.mod
       - name: Lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.57.2
-          ./bin/golangci-lint run
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.57.2

--- a/.github/workflows/go-slog.yml
+++ b/.github/workflows/go-slog.yml
@@ -11,11 +11,12 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
           check-latest: true
-      - uses: actions/checkout@v4
+          cache-dependency-path: go.mod
       - name: go mod tidy
         run: |
           mkdir bench


### PR DESCRIPTION
This PR does the following:

1. Setup Dependabot to check for new versions of actions every week. See https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#example-dependabotyml-file-for-github-actions

2. Update `actions/setup-go` to `v5` to resolve the deprecation warning

   ![image](https://github.com/user-attachments/assets/f2988cbd-5975-4a3e-9fae-f3a123fb9460)

3. Since this module has zero dependencies and thus no `go.sum` file, we can set `cache-dependency-path` to `go.mod` to resolve the "Dependencies file is not found" warning. 

   ![image](https://github.com/user-attachments/assets/111a419d-3f1a-4306-bdb6-5163ed1729e5)

