### PR TITLE
Fix MaxSize rotation and MaxBackups for frequent short-lived processes (Issue #97)

### DIFF
--- a/file.go
+++ b/file.go
@@ -249,6 +249,11 @@ func (w *FileWriter) create() (err error) {
 		w.size = st.Size()
 	}
 
+	err = w.rotate()
+	if err != nil {
+		return err
+	}
+
 	if w.size == 0 && w.Header != nil {
 		if b := w.Header(st); b != nil {
 			n, err := w.file.Write(b)


### PR DESCRIPTION
This PR addresses Issue #97: "MaxSize Rotation Fails for Frequent Short-Lived Processes".

- Ensures log rotation and MaxBackups cleanup are enforced even when many short-lived processes write to the log.
- Updates the rotation logic to always trigger cleanup after file creation, not just when the file is oversized.
- Refactors and expands tests to cover both single-instance and multi-instance scenarios, with various TimeFormat, HostName, and ProcessID combinations.
- Makes the tests deterministic and reliable, regardless of system clock granularity.

Closes #97.