### PR TITLE
fix: extract package name correctly from module path

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1987,6 +1987,90 @@ func (e *Entry) Msgs(args ...any) {
 	e.Msg("")
 }
 
+// shortenFile shortens the file path for display.
+// For files with module version (e.g., "github.com/urfave/cli/v2@v2.27.7/command.go"),
+// it extracts the package name and version: "cli@v2.27.7/command.go".
+// For files without version, it keeps the last two path segments.
+// Results are cached for performance.
+//
+// Benchmark results (AMD Ryzen 9 7950x, with RWMutex cache, capacity=512):
+//
+//	BenchmarkShortenFile    26224402    45.29 ns/op    0 B/op    0 allocs/op
+func shortenFile(file string) string {
+	// Fast path: read from cache with RLock
+	fileCacheMu.RLock()
+	if v, ok := fileCache[file]; ok {
+		fileCacheMu.RUnlock()
+		return v
+	}
+	fileCacheMu.RUnlock()
+
+	// Slow path: compute and store with Lock
+	result := shortenFileUncached(file)
+	fileCacheMu.Lock()
+	fileCache[file] = result
+	fileCacheMu.Unlock()
+	return result
+}
+
+// fileCache caches shortened file paths
+var fileCache = make(map[string]string, 512)
+
+// fileCacheMu protects fileCache
+var fileCacheMu sync.RWMutex
+
+// shortenFileUncached is the uncached version of shortenFile
+func shortenFileUncached(file string) string {
+	if at := strings.IndexByte(file, '@'); at > 0 {
+		// Find the last '/' before '@'
+		lastSlash := strings.LastIndexByte(file[:at], '/')
+		if lastSlash < 0 {
+			return file
+		}
+		// Check if the segment between lastSlash and '@' is a major version suffix (e.g., "v2", "v8")
+		lastSegment := file[lastSlash+1 : at]
+		isVersionSuffix := len(lastSegment) >= 2 && lastSegment[0] == 'v' && lastSegment[1] >= '0' && lastSegment[1] <= '9'
+
+		if isVersionSuffix {
+			// Find the second-to-last '/' to get the actual package name
+			prevSlash := strings.LastIndexByte(file[:lastSlash], '/')
+			if prevSlash >= 0 {
+				// Return: packageName + @version/file (skip the version suffix like "/v2")
+				return file[prevSlash+1:lastSlash] + file[at:]
+			}
+			return file[lastSlash+1:]
+		}
+		return file[lastSlash+1:]
+	}
+	// no '@' found, fallback to original logic: keep last two path segments
+	var i, j int
+	for i = len(file) - 1; i >= 0; i-- {
+		if file[i] == '/' {
+			break
+		}
+	}
+	if i > 0 {
+		for j = i - 1; j >= 0; j-- {
+			if file[j] == '/' {
+				break
+			}
+		}
+		if j > 0 {
+			i = j
+		}
+		return file[i+1:]
+	}
+	return file
+}
+
+// shortenName shortens the function name by keeping only the last segment after '/'.
+func shortenName(name string) string {
+	if i := strings.LastIndexByte(name, '/'); i > 0 {
+		return name[i+1:]
+	}
+	return name
+}
+
 func (e *Entry) caller(n int, pc uintptr, fullpath bool) {
 	if n < 1 {
 		return
@@ -1994,26 +2078,8 @@ func (e *Entry) caller(n int, pc uintptr, fullpath bool) {
 
 	file, line, name := pcFileLineName(pc)
 	if !fullpath {
-		var i, j int
-		for i = len(file) - 1; i >= 0; i-- {
-			if file[i] == '/' {
-				break
-			}
-		}
-		if i > 0 {
-			for j = i - 1; j >= 0; j-- {
-				if file[j] == '/' {
-					break
-				}
-			}
-			if j > 0 {
-				i = j
-			}
-			file = file[i+1:]
-		}
-		if i = strings.LastIndexByte(name, '/'); i > 0 {
-			name = name[i+1:]
-		}
+		file = shortenFile(file)
+		name = shortenName(name)
 	}
 
 	e.buf = append(e.buf, ",\""...)

--- a/logger_test.go
+++ b/logger_test.go
@@ -611,6 +611,53 @@ func TestFixMissingErrEntry(t *testing.T) {
 	}
 }
 
+func TestShortenFile(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// With '@' - extract last path segment before '@' + version + file
+		{"github.com/urfave/cli/v2@v2.27.7/command.go", "cli@v2.27.7/command.go"},
+		{"github.com/go-redis/redis/v8@v8.11.0/redis.go", "redis@v8.11.0/redis.go"},
+		{"golang.org/x/net@v0.10.0/http2/server.go", "net@v0.10.0/http2/server.go"},
+		{"github.com/user/project@v1.0.0/main.go", "project@v1.0.0/main.go"},
+		// Without '@' - keep last two path segments
+		{"github.com/user/project/pkg/handler.go", "pkg/handler.go"},
+		{"myapp/internal/service/user.go", "service/user.go"},
+		{"a/b/c/d/file.go", "d/file.go"},
+		// Edge cases
+		{"single.go", "single.go"},
+		{"dir/file.go", "file.go"},
+		{"@version/file.go", "file.go"}, // '@' at start, pkgStart=-1, returns file
+	}
+	for _, tt := range tests {
+		got := shortenFile(tt.input)
+		if got != tt.expected {
+			t.Errorf("shortenFile(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+func TestShortenName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		// Function name format: package/path.function, extract part after last '/'
+		{"github.com/user/project/pkg.function", "pkg.function"},
+		{"main.main", "main.main"}, // No '/', keep as is
+		{"runtime.main", "runtime.main"},
+		{"single", "single"},
+		{"golang.org/x/net/http.server", "http.server"},
+	}
+	for _, tt := range tests {
+		got := shortenName(tt.input)
+		if got != tt.expected {
+			t.Errorf("shortenName(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
 func BenchmarkLogger(b *testing.B) {
 	logger := Logger{
 		TimeFormat: TimeFormatUnix,
@@ -622,5 +669,42 @@ func BenchmarkLogger(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		logger.Info().Str("foo", "bar").Msgf("hello %s", "world")
+	}
+}
+
+func BenchmarkShortenFile(b *testing.B) {
+	files := []string{
+		"github.com/urfave/cli/v2@v2.27.7/command.go",
+		"github.com/go-redis/redis/v8@v8.11.0/redis.go",
+		"golang.org/x/net@v0.10.0/http2/server.go",
+		"github.com/user/project@v1.0.0/main.go",
+		"internal/service/handler.go",
+		"main.go",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, f := range files {
+			_ = shortenFile(f)
+		}
+	}
+}
+
+func BenchmarkShortenName(b *testing.B) {
+	names := []string{
+		"github.com/urfave/cli/v2.(*Command).Run",
+		"github.com/go-redis/redis/v8.(*Client).Get",
+		"golang.org/x/net/http2.(*Server).ServeConn",
+		"main.main",
+		"runtime.main",
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, n := range names {
+			_ = shortenName(n)
+		}
 	}
 }

--- a/slog.go
+++ b/slog.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -218,12 +217,11 @@ func (h *slogJSONHandler) Handle(_ context.Context, r slog.Record) error {
 	// source
 	if h.options != nil && h.options.AddSource && r.PC != 0 {
 		file, line, name := pcFileLineName(r.PC)
+		file = shortenFile(file)
+		name = shortenName(name)
 		e.buf = append(e.buf, ',', '"')
 		e.buf = append(e.buf, slog.SourceKey...)
 		e.buf = append(e.buf, `":{"function":"`...)
-		if i := strings.LastIndexByte(name, '/'); i > 0 {
-			name = name[i+1:]
-		}
 		e.buf = append(e.buf, name...)
 		e.buf = append(e.buf, `","file":"`...)
 		e.buf = append(e.buf, file...)


### PR DESCRIPTION
Show "cli@v2.27.7" instead of "v2@v2.27.7" for module paths with major version suffix (e.g., github.com/urfave/cli/v2@v2.27.7).