### PR TITLE
fix retrieving incorrect timestamp from XID

### DIFF
--- a/xid.go
+++ b/xid.go
@@ -42,7 +42,7 @@ func NewXIDWithTime(timestamp int64) (x XID) {
 
 // Time returns the timestamp part of the id.
 func (x XID) Time() time.Time {
-	return time.Unix(int64(x[0])<<32|int64(x[1])<<16|int64(x[2])<<8|int64(x[3]), 0)
+	return time.Unix(int64(x[0])<<24|int64(x[1])<<16|int64(x[2])<<8|int64(x[3]), 0)
 }
 
 // Machine returns the 3-byte machine id part of the id.


### PR DESCRIPTION
This PR fixes incorrect parsing of the timestamp from a XID.

Consider example below:
```go
func main() {
	l := log.DefaultLogger
	xid := log.NewXID()
	l.Log().Time("xid_time", xid.Time()).Msg("")
}
```

Before:
`{"time":"2026-04-02T22:13:41.988+05:00","xid_time":"16261-02-24T06:13:41+05:00"}`

After:
`{"time":"2026-04-02T22:13:48.428+05:00","xid_time":"2026-04-02T22:13:48+05:00"}`