### PR TITLE
Add GCCGo support

### DIFF
--- a/async_linux.go
+++ b/async_linux.go
@@ -21,7 +21,7 @@ func (w *AsyncWriter) writever() {
 			break
 		}
 		iovs[0].Base = &es[0].buf[0]
-		iovs[0].Len = uint64(len(es[0].buf))
+		iovs[0].SetLen(len(es[0].buf))
 		// drain the channel
 		length := len(w.ch)
 		if length > IOV_MAX-1 {
@@ -35,7 +35,7 @@ func (w *AsyncWriter) writever() {
 				break
 			}
 			iovs[n].Base = &es[n].buf[0]
-			iovs[n].Len = uint64(len(es[n].buf))
+			iovs[n].SetLen(len(es[n].buf))
 			n++
 		}
 		// writev

--- a/fastcaller_go1.18.go
+++ b/fastcaller_go1.18.go
@@ -1,4 +1,4 @@
-//go:build go1.18 && !go1.19
+//go:build gc && go1.18 && !go1.19
 
 // MIT license, copy and modify from https://github.com/tlog-dev/loc
 

--- a/fastcaller_go1.19.go
+++ b/fastcaller_go1.19.go
@@ -1,4 +1,4 @@
-//go:build go1.19 && !go1.20
+//go:build gc && go1.19 && !go1.20
 
 // MIT license, copy and modify from https://github.com/tlog-dev/loc
 

--- a/fastcaller_go1.20.go
+++ b/fastcaller_go1.20.go
@@ -1,4 +1,4 @@
-//go:build go1.20 && !go1.21
+//go:build gc && go1.20 && !go1.21
 
 // MIT license, copy and modify from https://github.com/tlog-dev/loc
 

--- a/fastcaller_go1.21.go
+++ b/fastcaller_go1.21.go
@@ -1,4 +1,4 @@
-//go:build go1.21 && !go1.22
+//go:build gc && go1.21 && !go1.22
 
 // MIT license, copy and modify from https://github.com/tlog-dev/loc
 

--- a/fastcaller_go1.22.go
+++ b/fastcaller_go1.22.go
@@ -1,4 +1,4 @@
-//go:build go1.22 && !go1.23
+//go:build gc && go1.22 && !go1.23
 
 // MIT license, copy and modify from https://github.com/tlog-dev/loc
 

--- a/fastcaller_go1.23.go
+++ b/fastcaller_go1.23.go
@@ -1,4 +1,4 @@
-//go:build go1.23
+//go:build gc && go1.23
 
 // MIT license, copy and modify from https://github.com/tlog-dev/loc
 

--- a/goid.go
+++ b/goid.go
@@ -1,4 +1,4 @@
-//go:build amd64 || arm64 || arm || 386 || mipsle || riscv64
+//go:build gc && (amd64 || arm64 || arm || 386 || mipsle || riscv64)
 
 package log
 

--- a/goid_go1.18.s
+++ b/goid_go1.18.s
@@ -1,5 +1,5 @@
-//go:build go1.18 && !go1.23
-// +build go1.18,!go1.23
+//go:build gc && go1.18 && !go1.23
+// +build gc,go1.18,!go1.23
 
 #include "textflag.h"
 

--- a/goid_go1.23.s
+++ b/goid_go1.23.s
@@ -1,5 +1,5 @@
-//go:build go1.23 && !go1.25
-// +build go1.23,!go1.25
+//go:build gc && go1.23 && !go1.25
+// +build gc,go1.23,!go1.25
 
 #include "textflag.h"
 

--- a/goid_go1.25.s
+++ b/goid_go1.25.s
@@ -1,5 +1,5 @@
-//go:build go1.25
-// +build go1.25
+//go:build gc && go1.25
+// +build gc,go1.25
 
 #include "textflag.h"
 

--- a/goid_safe.go
+++ b/goid_safe.go
@@ -1,4 +1,4 @@
-//go:build !amd64 && !arm64 && !arm && !386 && !mipsle && !riscv64
+//go:build gc && !amd64 && !arm64 && !arm && !386 && !mipsle && !riscv64
 
 package log
 

--- a/logger.go
+++ b/logger.go
@@ -2516,15 +2516,3 @@ func b2s(b []byte) string { return *(*string)(unsafe.Pointer(&b)) }
 //go:noescape
 //go:linkname now time.now
 func now() (sec int64, nsec int32, mono int64)
-
-//go:noescape
-//go:linkname absDate time.absDate
-func absDate(abs uint64, full bool) (year int, month time.Month, day int, yday int)
-
-//go:noescape
-//go:linkname absClock time.absClock
-func absClock(abs uint64) (hour, min, sec int)
-
-//go:noescape
-//go:linkname caller1 runtime.callers
-func caller1(skip int, pc *uintptr, len, cap int) int

--- a/runtime_gc.go
+++ b/runtime_gc.go
@@ -1,0 +1,20 @@
+//go:build gc
+
+package log
+
+import (
+	"time"
+	_ "unsafe"
+)
+
+//go:noescape
+//go:linkname absDate time.absDate
+func absDate(abs uint64, full bool) (year int, month time.Month, day int, yday int)
+
+//go:noescape
+//go:linkname absClock time.absClock
+func absClock(abs uint64) (hour, min, sec int)
+
+//go:noescape
+//go:linkname caller1 runtime.callers
+func caller1(skip int, pc *uintptr, len, cap int) int

--- a/runtime_gccgo.go
+++ b/runtime_gccgo.go
@@ -1,0 +1,174 @@
+//go:build gccgo
+
+package log
+
+import (
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+const (
+	secondsPerMinute = 60
+	secondsPerHour   = 60 * secondsPerMinute
+	secondsPerDay    = 24 * secondsPerHour
+	daysPer400Years  = 365*400 + 97
+	daysPer100Years  = 365*100 + 24
+	daysPer4Years    = 365*4 + 1
+	absoluteZeroYear = -292277022399
+)
+
+var gccgoDaysBefore = [...]int32{0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334, 365}
+
+// gccgoG matches libgo's runtime.g through the goid field.
+type gccgoG struct {
+	_panic       unsafe.Pointer
+	_defer       unsafe.Pointer
+	m            unsafe.Pointer
+	syscallsp    uintptr
+	syscallpc    uintptr
+	param        unsafe.Pointer
+	atomicstatus uint32
+	goid         int64
+}
+
+//go:noescape
+//go:linkname gccgoGetg runtime.getg
+func gccgoGetg() *gccgoG
+
+func goid() int {
+	return int(gccgoGetg().goid)
+}
+
+// Goid returns the current goroutine id.
+// It exactly matches goroutine id of the stack trace.
+func Goid() int64 {
+	return int64(goid())
+}
+
+// BSD-3-Clause, copied from Go's time.absDate.
+func absDate(abs uint64, full bool) (year int, month time.Month, day int, yday int) {
+	d := abs / secondsPerDay
+	n := d / daysPer400Years
+	y := 400 * n
+	d -= daysPer400Years * n
+	n = d / daysPer100Years
+	n -= n >> 2
+	y += 100 * n
+	d -= daysPer100Years * n
+	n = d / daysPer4Years
+	y += 4 * n
+	d -= daysPer4Years * n
+	n = d / 365
+	n -= n >> 2
+	y += n
+	d -= 365 * n
+	year = int(int64(y) + absoluteZeroYear)
+	yday = int(d)
+	if !full {
+		return
+	}
+
+	day = yday
+	if year%4 == 0 && (year%100 != 0 || year%400 == 0) {
+		switch {
+		case day > 31+29-1:
+			day--
+		case day == 31+29-1:
+			return year, time.February, 29, yday
+		}
+	}
+
+	month = time.Month(day / 31)
+	begin := int(gccgoDaysBefore[month])
+	if end := int(gccgoDaysBefore[month+1]); day >= end {
+		month++
+		begin = end
+	}
+	month++
+	day = day - begin + 1
+	return
+}
+
+func absClock(abs uint64) (hour, min, sec int) {
+	sec = int(abs % secondsPerDay)
+	hour = sec / secondsPerHour
+	sec -= hour * secondsPerHour
+	min = sec / secondsPerMinute
+	sec -= min * secondsPerMinute
+	return
+}
+
+// gccgoLocation must match runtime.location.
+type gccgoLocation struct {
+	pc       uintptr
+	filename string
+	function string
+	lineno   int
+}
+
+//go:noescape
+//extern runtime_callers
+func gccgoCallers(skip int32, locbuf *gccgoLocation, max int32, keepThunks bool) int32
+
+//go:noescape
+//go:linkname gccgoFuncFileLine runtime.funcfileline
+func gccgoFuncFileLine(pc uintptr, index int32, more bool) (name, file string, line, frames int)
+
+//go:noescape
+//go:linkname gccgoDecodeIdentifier runtime.decodeIdentifier
+func gccgoDecodeIdentifier([]byte) int
+
+//go:noinline
+func caller1(skip int, pc *uintptr, length, capacity int) int {
+	if pc == nil || skip < 0 || length < 1 || capacity < 1 {
+		return 0
+	}
+	var location gccgoLocation
+	if gccgoCallers(int32(skip+1), &location, 1, false) != 1 {
+		return 0
+	}
+	*pc = location.pc
+	return 1
+}
+
+// Fastrandn returns a pseudorandom uint32 in [0,n).
+//
+//go:noescape
+//go:linkname Fastrandn runtime.fastrandn
+func Fastrandn(n uint32) uint32
+
+func pcFileLine(pc uintptr) (file string, line int) {
+	if pc == 0 {
+		return "", 0
+	}
+	_, file, line, _ = gccgoFuncFileLine(pc-1, -1, false)
+	return file, line
+}
+
+func pcFileLineName(pc uintptr) (file string, line int, name string) {
+	if pc == 0 {
+		return "", 0, ""
+	}
+	name, file, line, _ = gccgoFuncFileLine(pc-1, -1, false)
+	return file, line, demangleGCCGoSymbol(name)
+}
+
+var gccgoSymbolCache sync.Map
+
+// demangleGCCGoSymbol reverses gccgo's underscore encoding. Libgo's low-level
+// symbol lookup returns the encoded name; CallersFrames normally decodes it.
+func demangleGCCGoSymbol(name string) string {
+	if !strings.Contains(name, ".") || !strings.Contains(name, "_") {
+		return name
+	}
+	if decoded, ok := gccgoSymbolCache.Load(name); ok {
+		return decoded.(string)
+	}
+
+	b := []byte(name)
+	decoded := string(b[:gccgoDecodeIdentifier(b)])
+	actual, _ := gccgoSymbolCache.LoadOrStore(name, decoded)
+	return actual.(string)
+}


### PR DESCRIPTION
Adds GCCGo support without changing the normal Go path.

The gc-only links were moved from `logger.go` to `runtime_gc.go` because GCCGo cannot resolve those private `time` and `runtime` symbols, and build tags apply to whole files. `runtime_gccgo.go` provides the GCCGo versions instead.

The date code is adapted from Go's internal `time.absDate` and `time.absClock`, while the runtime hooks follow libgo.

`Iovec.SetLen` replaces the direct `uint64` assignment because GCCGo defines `Iovec.Len` as its own `Iovec_len_t` type. The setter handles the correct type for either compiler.

Tested with GCCGo and real builds of Goop, HWSkynet-KOOK, and Go-Tasks.
